### PR TITLE
Modest mo_cloud_sampling changes (cosmetic, commentary, speed, and possible bug fix to exp_ran)

### DIFF
--- a/rrtmgp/kernels/mo_gas_optics_kernels.F90
+++ b/rrtmgp/kernels/mo_gas_optics_kernels.F90
@@ -707,7 +707,7 @@ contains
                                                      ! index(1) : reference eta level (temperature dependent)
                                                      ! index(2) : reference pressure level
                                                      ! index(3) : reference temperature level
-    real(wp), dimension(:,:,:,:),intent(in) :: k ! (gpt, eta,temp,press)
+    real(wp), dimension(:,:,:,:),intent(in) :: k ! (temp,eta,press,gpt)
     integer,                     intent(in) :: gptS, gptE
     integer, dimension(2),       intent(in) :: jeta ! interpolation index for binary species parameter (eta)
     integer,                     intent(in) :: jtemp ! interpolation index for temperature


### PR DESCRIPTION
new line#:
94,226,230,234,239,243: improved/corrected error message.
126,173,189,289: cosmetic or more consistent with elsewhere in code.
170&260: execution for cloud_lay_fst redundant ... overwritten subsequently.
195-203: more detailed commentary.
284-285: this looks like a bugfix ... existing 1.5 code would potentially leave cloud_mask for intra-cloud clear layers uninitialized.
